### PR TITLE
updated solana sdk

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-solana-sdk = "^1.8.1"
-solana-cli-config = "^1.8.1"
-solana-client = "^1.8.1"
+solana-sdk = "^1.11.5"
+solana-cli-config = "^1.11.5"
+solana-client = "^1.11.5"
 ark-ec = { version = "0.3.0", default-features = false}
 ark-bn254 = { version = "0.3.0", features = ["curve"]}
 circuit = { version = "0.1.0", path = "../circuit"}

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -16,9 +16,9 @@ use solana_sdk::transaction::Transaction;
 use circuit::initialize;
 
 const CONTRACT_SO_PATH: &str =
-    "/mnt/e/Programs/zklink/groth16-sol-verifier/target/deploy/contract.so";
+    "/Users/mauriciobarba/repos/zkops/circommul/rust_verifier/solana/groth16-sol-verifier/target/deploy/contract.so";
 const CONTRACT_KEYPAIR_PATH: &str =
-    "/mnt/e/Programs/zklink/groth16-sol-verifier/target/deploy/contract-keypair.json";
+    "/Users/mauriciobarba/repos/zkops/circommul/rust_verifier/solana/groth16-sol-verifier/target/deploy/contract-keypair.json";
 const SIZE: usize = 384;
 
 pub struct Client {
@@ -125,7 +125,7 @@ impl Client {
                 SIZE as u64,
                 &self.program_id,
             );
-            let (recent_hash, _) = self.connection.get_recent_blockhash().unwrap();
+            let recent_hash = self.connection.get_latest_blockhash().unwrap();
             let transaction = Transaction::new_signed_with_payer(
                 &[intruction],
                 Some(&self.payer.pubkey()),
@@ -276,7 +276,6 @@ impl Client {
         // run a circuit demo
         let (proof_c, prepared_input, qap) = initialize().unwrap();
         println!("run a circuit demo, get input and proof");
-
         // create accounts for verify
         let mut keys = vec![];
         keys.push(self.check_account("gamma"));
@@ -301,10 +300,11 @@ impl Client {
             .iter()
             .map(|key| AccountMeta::new(*key, false))
             .collect();
-        let (recent_hash, _) = self.connection.get_recent_blockhash().unwrap();
+        let recent_hash = self.connection.get_latest_blockhash().unwrap();
 
-        let i1 = solana_sdk::compute_budget::request_units(1_000_000 as u32);
-
+        let i1 = solana_sdk::compute_budget::ComputeBudgetInstruction::set_compute_unit_limit(1_000_000 as u32);
+        println!("{:?}", accounts);
+        println!("{:?}", data.as_slice());
         let i2 = solana_sdk::instruction::Instruction::new_with_bytes(
             self.program_id,
             data.as_slice(),

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -16,7 +16,7 @@ no-entrypoint = []
 test-bpf = []
 
 [dependencies]
-solana-program = "^1.8.1"
+solana-program = "^1.11.5"
 ark-groth16 = { version = "0.3.0", default-features = false}
 ark-std = { version = "^0.3.0", features = ["std"]}
 ark-ff = { version = "^0.3.0", default-features = false}
@@ -26,5 +26,5 @@ num-traits = "0.2.14"
 arrayref = "0.3.6"
 
 [dev-dependencies]
-solana-program-test = "=1.8.1"
-solana-sdk = "=1.8.1"
+solana-program-test = "=1.11.5"
+solana-sdk = "=1.11.5"


### PR DESCRIPTION
Previously was on version 1.8.1 which is incompatible with current Solana CLI and testnet/devnet. This updates Solana sdk and replaces deprecated functions with their updated counterparts.